### PR TITLE
Improve documentation, setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,74 @@
 # 5calls
 
-## Setup for Dev
+5calls is split into two pieces
 
-### frontend
+* Site front end, written in Javascript, using Choo
+* Application server back end, for data processing, written in Go
 
-Install the requirements with:
+To make display changes, you likely won't need to handle the application
+server, and can instead rely on the production version of 5calls, running at
+5calls.org -- more on this below.
+
+## Development
+
+### Front End
+
+Front end requirements must first be installed with:
 `npm install`
-and
+
+Gulp is used to compile front end static assets. If you do not have Gulp
+installed globally, you can install this with:
 `npm install -g gulp`
 
-Then you can just use gulp to generate the site and watch for changes:
+Gulp is configured, by default, to watch and recompile front end files when
+any changes are detected. You can run Gulp in this mode with:
 `gulp`
 
-In a new terminal, use any web server to serve the compiled source locally, like python:
-`cd app/static && python -m SimpleHTTPServer`
+This default command will also spin up an HTTP server for serving the site
+files on port `tcp/8000`.
 
-A development site should be available at http://localhost:8000
+The other main Gulp task is the `deploy` task, which does not watch for
+changes, and applies addition transforms on the assets -- such as an uglify
+transform on Javascript sources.
 
-### go
+### Application Server
 
-In the go directory, use the go tool to run the code:
-`go run *.go`
+If you need to make any changes to the back end code, you'll need to set up
+your environment for Go development -- see [How to Write Go
+Code](https://golang.org/doc/code.html) for more information on this.
+
+With your environment set up, you should first start by installing
+dependencies. In the `go/` path, this will install these dependencies for you:
+`make deps`
+
+To run the application code:
+`make run`
+
+To build the application code to a binary file:
+`make`
+
+You will need to build the application to a binary in order to pass in
+arguments, such as the Airtable database ID:
+`./fivecalls --airtable-base=XXX`
+
+#### Running Locally
+
+There are several requirements to setting up the application server:
+
+* A [Google Civic Information API][civic-api] key
+* An [Airtable][airtable] API key
+* An [Airtable][airtable] database
+* [Airtable][airtable] database ID
+* Locally override the application server in the front end code
+
+To set up the Airtable database, first create a database in Airtable. You can
+get the database ID from the API afterwards. This piece will be passed into
+the `fivecalls` binary, using the `--airtable-base` command line argument.
+
+TODO: Airtable schema
+
+[airtable]: https://airtable.com
+[civic-api]: https://developers.google.com/civic-information/
 
 ## Deployment
 

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,13 +1,31 @@
+# Default GOPATH to the current directory
+GOPATH ?= `pwd`
 
-# make everything for here
-all:
+.PHONY: default build build-dev build-prod deploy deploy-static deploy_static
+
+default: build-dev
+
+build: build-prod
+
+# Install dependencies
+deps:
+	set -e
+	set -x
+	go get
+
+# Run with reload
+run:
+	GOPATH=$(GOPATH) go run *.go
+
+# Build binary file locally
+build-dev:
 	set -e
 	set -x
 
-	go build -o fivecalls
+	GOPATH=$(GOPATH) go build -o fivecalls
 	echo "Build done"
 
-build:
+build-prod:
 	set -e
 	set -x
 
@@ -33,6 +51,8 @@ deploy:
 	scp -C fivecalls-linux-amd64 fivecalls@5calls.org:/home/fivecalls/fivecalls-linux-amd64.tmp
 	ssh fivecalls@5calls.org install /home/fivecalls/fivecalls-linux-amd64.tmp /home/fivecalls/fivecalls-linux-amd64
 	echo "Uploaded."
+
+deploy-static: deploy_static
 
 deploy_static:
 	cd .. && gulp deploy

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,11 +4,14 @@ var gulp = require('gulp')
   , sass = require('gulp-sass')
   , autoprefixer = require('gulp-autoprefixer')
   , imagemin = require('gulp-imagemin')
+  , util = require('gulp-util')
   , browserify = require('browserify')
   , es2040 = require('es2040')
   , buffer = require('vinyl-buffer')
   , source = require('vinyl-source-stream')
   , uglify = require('gulp-uglify')
+  , http_server = require('http-server')
+  , connect_logger = require('connect-logger')
   ;
 
 var SRC = {
@@ -33,6 +36,17 @@ gulp.task('html', function() {
 
 gulp.task('html:watch', function() {
   gulp.watch(`${SRC.html}/*.html`, ['html']);
+});
+
+gulp.task('html:serve', function (cb) {
+  var server = new http_server.HttpServer({
+    root: 'app/static',
+    before: [connect_logger()]
+  });
+  server.listen(8000, function () {
+    util.log('HTTP server started on port 8000');
+    cb();
+  });
 });
 
 // Compile Sass into CSS
@@ -97,5 +111,5 @@ gulp.task('extra', function() {
     .pipe(gulp.dest(DEST.html));
 });
 
-gulp.task('default', ['html', 'html:watch', 'sass', 'sass:watch', 'copy-images', 'copy-images:watch', 'scripts', 'scripts:watch', 'extra']);
+gulp.task('default', ['html', 'html:watch', 'html:serve', 'sass', 'sass:watch', 'copy-images', 'copy-images:watch', 'scripts', 'scripts:watch', 'extra']);
 gulp.task('deploy', ['html', 'sass', 'build-scripts', 'extra', 'copy-images']);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   },
   "dependencies": {
     "choo": "^4.0.0",
+    "connect-logger": "0.0.1",
+    "gulp-util": "^3.0.8",
+    "http-server": "^0.9.0",
     "lodash": "^4.17.2",
     "query-string": "^4.2.3",
     "scroll-into-view": "^1.7.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-click==6.6
-Flask==0.11.1
-itsdangerous==0.24
-Jinja2==2.8
-MarkupSafe==0.23
-Werkzeug==0.11.11
-Flask-SQLAlchemy==2.1


### PR DESCRIPTION
Setup steps were lacking for the application server. I've added some information
that hopefully helps here. It didn't seem necessary to run a Python process to
server HTTP, so I included a gulp task for serving these files from Gulp. I'm
not sure what the production serving mechanism looks like however.

This also adds some convenience make targets for the setup steps. I'm not super
confident with Go however, so perhaps this introduces other problems.